### PR TITLE
Dev parse chunk

### DIFF
--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 14:02:00 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 14:27:15 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,13 +139,10 @@ int Request::parseRequest() {
     return parseChunkedBody(pos_buf);
   }
   /* store body based on content-length value*/
-  else if (content_length_ > 0 &&
-           parse_progress_ == 2) {  // 2: finished parse header then body
-    if (findBodyEndAndStore() < 0) {
-      return REQ_CONTINUE_RECV;
-    }
+  else if (content_length_ > 0) {
+    return findBodyEndAndStore();
   }
-  return REQ_FIN_RECV;
+return REQ_FIN_RECV;
 }
 
 /* get request line from the input (beginning to /r/n) */
@@ -191,9 +188,9 @@ ssize_t Request::findBodyEndAndStore() {
     body_ = buf_;
     std::vector<char>().swap(
         buf_);  // free memory of buf_ (c11 can use fit_to_shurink);
-    return 0;
+    return REQ_FIN_RECV;
   }
-  return -1;
+  return REQ_CONTINUE_RECV;
 }
 
 int Request::parseRequestLine() {

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 13:39:59 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 14:02:00 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@ const std::map<std::string, std::string>& Request::getQuery() const {
 }
 size_t Request::getContentLength() const { return content_length_; }
 const std::vector<char>& Request::getBody() const { return body_; }
+int Request::getFlgChunked() const { return flg_chunked_; };
 
 /* make string from a part of buf*/
 std::string Request::bufToString(size_t begin, size_t end) {

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/31 13:55:04 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/03/31 21:22:57 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -316,7 +316,17 @@ int Request::checkHeaderField() {
   }
   std::map<std::string, std::string>::iterator itr_content_length =
       headers_.find("content-length");
-  if (method_ == "POST" && itr_content_length == headers_.end()) {
+  std::map<std::string, std::string>::iterator itr_transfer_encoding =
+      headers_.find("transfer-encoding");
+  if (itr_transfer_encoding != headers_.end()) {
+    for (std::string::iterator itr = itr_transfer_encoding->second.begin();
+         itr != itr_transfer_encoding->second.end(); ++itr)
+      *itr = std::tolower(*itr);
+  }
+  /* POST requires content-length or transfer-encoding of chunked*/
+  if (method_ == "POST" && itr_content_length == headers_.end() &&
+      (itr_transfer_encoding == headers_.end() ||
+       itr_transfer_encoding->second != "chunked")) {
     return REQ_ERR_LEN_REQUIRED;
   }
   /*in case of content-length is negative or non digit */

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 13:18:28 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:39:59 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -188,7 +188,8 @@ ssize_t Request::findBodyEndAndStore() {
     buf_.erase(buf_.end() - excess, buf_.end());
     buf_.erase(buf_.begin(), buf_.begin() + pos_begin_body_);
     body_ = buf_;
-    std::vector<char>().swap(buf_);//free memory of buf_ (c11 can use fit_to_shurink);
+    std::vector<char>().swap(
+        buf_);  // free memory of buf_ (c11 can use fit_to_shurink);
     return 0;
   }
   return -1;
@@ -373,8 +374,7 @@ ssize_t Request::parseChunkedBody(size_t pos) {
             return REQ_ERR_BAD_REQUEST;
           }
         }
-        chunk_size_ =
-            ft_atoul_hexbase(chunk_size.c_str());
+        chunk_size_ = ft_atoul_hexbase(chunk_size.c_str());
         parse_progress_ = 3;
         pos_prev_ = pos + 2;
         return REQ_CONTINUE_RECV;
@@ -384,7 +384,8 @@ ssize_t Request::parseChunkedBody(size_t pos) {
           return REQ_ERR_BAD_REQUEST;
         } else {
           if (chunk_size_ == 0) {  // finish chunked data transfer
-            std::vector<char>().swap(buf_);//free memory of buf_ (c11 can use fit_to_shurink);
+            std::vector<char>().swap(
+                buf_);  // free memory of buf_ (c11 can use fit_to_shurink);
             return REQ_FIN_RECV;
           }
           body_.insert(body_.end(), buf_.begin() + begin, buf_.begin() + pos);

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 13:04:52 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:06:07 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -187,6 +187,7 @@ ssize_t Request::findBodyEndAndStore() {
   if (excess >= 0) {
     buf_.erase(buf_.end() - excess, buf_.end());
     buf_.erase(buf_.begin(), buf_.begin() + pos_begin_body_);
+    body_ = buf_;
     return 0;
   }
   return -1;

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/05 20:17:20 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/05 20:19:24 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -374,7 +374,9 @@ ssize_t Request::parseChunkedBody(size_t pos) {
           }
         }
         chunk_size_ = ft_atoul_hexbase(chunk_size.c_str());
-        parse_progress_ = REQ_GOT_CHUNK_SIZE;
+        parse_progress_ =
+            REQ_GOT_CHUNK_SIZE;  // Then next should be getting chunked data in
+                                 // else part of this function
         pos_prev_ = pos + 2;
         return REQ_CONTINUE_RECV;
         /* get chunked data body*/

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/01 23:28:43 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 12:22:57 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,7 @@ const std::map<std::string, std::string>& Request::getQuery() const {
   return query_;
 }
 size_t Request::getContentLength() const { return content_length_; }
+const std::vector<char>& Request::getBody() const { return body_; }
 
 /* make string from a part of buf*/
 std::string Request::bufToString(size_t begin, size_t end) {
@@ -366,11 +367,12 @@ ssize_t Request::parseChunkedBody(size_t pos) {
         for (std::string::iterator itr = chunk_size.begin();
              itr != chunk_size.end(); ++itr) {
           if (!(isdigit(*itr) || ('a' <= *itr && *itr <= 'f') ||
-              ('A' <= *itr && *itr <= 'F'))) {
+                ('A' <= *itr && *itr <= 'F'))) {
             return REQ_ERR_BAD_REQUEST;
           }
         }
-        chunk_size_ = ft_atoul(chunk_size.c_str());
+        chunk_size_ =
+            ft_atoul(chunk_size.c_str());  // should be replace by hex func
         parse_progress_ = 3;
         pos_prev_ = pos + 2;
         return REQ_CONTINUE_RECV;
@@ -382,6 +384,7 @@ ssize_t Request::parseChunkedBody(size_t pos) {
           if (chunk_size_ == 0) {  // finish chunked data transfer
             return REQ_FIN_RECV;
           }
+          body_.insert(body_.end(), buf_.begin() + begin, buf_.begin() + pos);
           parse_progress_ = 2;
           pos_prev_ = pos + 2;
           return REQ_CONTINUE_RECV;

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 12:22:57 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:04:52 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -372,7 +372,7 @@ ssize_t Request::parseChunkedBody(size_t pos) {
           }
         }
         chunk_size_ =
-            ft_atoul(chunk_size.c_str());  // should be replace by hex func
+            ft_atoul_hexbase(chunk_size.c_str());
         parse_progress_ = 3;
         pos_prev_ = pos + 2;
         return REQ_CONTINUE_RECV;

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 13:06:07 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:18:28 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -188,6 +188,7 @@ ssize_t Request::findBodyEndAndStore() {
     buf_.erase(buf_.end() - excess, buf_.end());
     buf_.erase(buf_.begin(), buf_.begin() + pos_begin_body_);
     body_ = buf_;
+    std::vector<char>().swap(buf_);//free memory of buf_ (c11 can use fit_to_shurink);
     return 0;
   }
   return -1;
@@ -383,6 +384,7 @@ ssize_t Request::parseChunkedBody(size_t pos) {
           return REQ_ERR_BAD_REQUEST;
         } else {
           if (chunk_size_ == 0) {  // finish chunked data transfer
+            std::vector<char>().swap(buf_);//free memory of buf_ (c11 can use fit_to_shurink);
             return REQ_FIN_RECV;
           }
           body_.insert(body_.end(), buf_.begin() + begin, buf_.begin() + pos);

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/05 20:14:40 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/05 20:17:20 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,7 @@ int Request::parseRequest() {
     pos_prev_ = pos_begin_header_;
   }
   if (parse_progress_ ==
-      REQ_FIN_REQEST_LINE) {  // 1: finished parse request line then header
+      REQ_FIN_REQUEST_LINE) {  // 1: finished parse request line then header
     // check in case of no header field for first time only
     if (pos_prev_ == pos_begin_header_ && buf_[pos_begin_header_] == '\r' &&
         buf_[pos_begin_header_ + 1] == '\n') {
@@ -160,7 +160,7 @@ ssize_t Request::findRequestLineEnd() {
     ++pos;
   }
   if (buf_[pos] == '\n') {
-    parse_progress_ = REQ_FIN_REQEST_LINE;
+    parse_progress_ = REQ_FIN_REQUEST_LINE;
     return pos;
   } else {
     pos_prev_ = pos;

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 12:15:40 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:59:13 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,6 +71,7 @@ class Request {
   const std::map<std::string, std::string>& getQuery() const;
   size_t getContentLength() const;
   const std::vector<char>& getBody() const;
+  int getFlgChunked() const;
 
   int receive(int sock_fd);
   int appendRawData(char* raw_data);

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/02 13:59:13 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/05 20:14:41 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ extern "C" {
 #define BUFFER_SIZE 1024
 #define RETRY_TIME_MAX 10
 
+/* return value of parseRequest*/
 #define REQ_FIN_PARSE_HEADER 2   // finished parsing header
 #define REQ_CONTINUE_RECV 1      // continue to receive
 #define REQ_FIN_RECV 0           // finished receiving
@@ -31,6 +32,12 @@ extern "C" {
 #define REQ_ERR_HTTP_VERSION -2  // HTTP505
 #define REQ_ERR_LEN_REQUIRED -3  // HTTP411
 #define REQ_ERR_BAD_REQUEST -4   // HTTP400
+
+/* value of parse_progress_*/
+#define REQ_BEFORE_PARSE 0
+#define REQ_FIN_REQEST_LINE 1
+#define REQ_FIN_HEADER_FIELD 2
+#define REQ_GOT_CHUNK_SIZE 3
 
 class Request {
 #ifdef UNIT_TEST

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/05 20:14:41 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/05 20:17:22 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ extern "C" {
 
 /* value of parse_progress_*/
 #define REQ_BEFORE_PARSE 0
-#define REQ_FIN_REQEST_LINE 1
+#define REQ_FIN_REQUEST_LINE 1
 #define REQ_FIN_HEADER_FIELD 2
 #define REQ_GOT_CHUNK_SIZE 3
 

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/01 21:33:02 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 12:15:40 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@ class Request {
   std::string uri_;
   std::map<std::string, std::string> query_;
   std::map<std::string, std::string> headers_;
+  std::vector<char> body_;
   unsigned long content_length_;
   unsigned long chunk_size_;
 
@@ -69,6 +70,7 @@ class Request {
   const std::map<std::string, std::string>& getHeaders() const;
   const std::map<std::string, std::string>& getQuery() const;
   size_t getContentLength() const;
+  const std::vector<char>& getBody() const;
 
   int receive(int sock_fd);
   int appendRawData(char* raw_data);

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/31 13:54:32 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/01 21:33:02 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ class Request {
   // body*/
   std::vector<char> buf_;
   int parse_progress_;
+  int flg_chunked_;
   ssize_t pos_prev_;
   ssize_t pos_begin_header_;
   ssize_t pos_begin_body_;
@@ -52,6 +53,7 @@ class Request {
   std::map<std::string, std::string> query_;
   std::map<std::string, std::string> headers_;
   unsigned long content_length_;
+  unsigned long chunk_size_;
 
   Request(Request const& other);
   Request& operator=(Request const& other);
@@ -88,6 +90,8 @@ class Request {
   int parseHeaderField(size_t pos);
   int checkHeaderField();
   ssize_t findBodyEndAndStore();
+  ssize_t parseChunkedBody(size_t pos);
+
   std::string bufToString(size_t begin, size_t end);
   int compareBuf(size_t begin, const char* str);
 };

--- a/Session.cpp
+++ b/Session.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Session.cpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/31 15:30:12 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/02 14:03:38 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -198,7 +198,7 @@ int Session::checkReceiveReturn(int ret) {
 #ifndef UNIT_TEST
     setupServerAndLocationConfig();  // To get server and location config
 #endif
-    if (request_.getContentLength() == 0) {
+    if (!request_.getFlgChunked() && (request_.getContentLength() == 0)) {
       startCreateResponse();
     } else if (location_config_ &&
                request_.getContentLength() >

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+         #
+#    By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/08/21 08:47:29 by dnakano           #+#    #+#              #
-#    Updated: 2021/03/19 15:37:04 by dnakano          ###   ########.fr        #
+#    Updated: 2021/04/02 12:44:23 by dhasegaw         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -45,7 +45,7 @@ BONUSSRCNAME	:=	ft_lstnew.c ft_lstadd_front.c ft_lstsize.c ft_lstlast.c \
 					ft_atof_bintof.c ft_atof_dectobin_frac.c \
 					ft_atof_atobin.c ft_atof_atodec.c \
 					ft_atof_uint128_2.c ft_atof_uint128.c \
-					ft_atoul.c \
+					ft_atoul.c ft_atoul_hexbase.c \
 					ft_htons.c
 SRCDIR			:=	.
 SRCS			:=	$(addprefix $(SRCDIR)/,$(SRCNAME))

--- a/libft/ft_atoul_hexbase.c
+++ b/libft/ft_atoul_hexbase.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_atoul_hexbase.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/03/18 17:03:04 by dnakano           #+#    #+#             */
+/*   Updated: 2021/04/02 13:02:25 by dhasegaw         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+unsigned long	ft_atoul_hexbase(const char *str)
+{
+	unsigned long	num;
+	const char* 	base = "0123456789abcdef";
+	unsigned int	idx;
+	char			c;
+
+	num = 0;
+	while (ft_isspace(*str))
+		str++;
+	if (*str == '+')
+		str++;
+	while (ft_isdigit(*str) || ('a' <= *str && *str <= 'f')
+			|| ('A' <= *str && *str <= 'F'))
+	{
+		c = ft_tolower(*str);
+		idx = -1;
+		while (++idx < 16)
+			if (c == base[idx])
+				break ;
+		num = num * 16 + idx;
+		str++;
+	}
+	return num;
+}

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   libft.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/05 12:01:52 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/19 15:38:31 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/02 12:43:53 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,7 @@ char				*ft_strdup(const char *s1);
 
 int					ft_atoi(const char *str);
 unsigned long		ft_atoul(const char *str);
+unsigned long		ft_atoul_hexbase(const char *str);
 double				ft_atof(const char *s);
 char				*ft_itoa(int n);
 

--- a/test/unit_test/ParseRequest/test_parseRequest.cc
+++ b/test/unit_test/ParseRequest/test_parseRequest.cc
@@ -569,3 +569,95 @@ TEST_F(test_parseRequest, transferEncodingOK2) {
   std::string str(request.body_.begin(), request.body_.end());
   EXPECT_EQ(str, "01234");
 }
+
+TEST_F(test_parseRequest, transferEncodingOK3) {
+  appendVec(request.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "localhost\r\nLocation:\t  \tYokoh");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "ama\r\nlanguage: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "en-US\r\nTransfer-Encoding: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "chunked\r\n\r\n5\r\n01234\r\n3");
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_PARSE_HEADER);
+  EXPECT_EQ(request.method_, "POST");
+  EXPECT_EQ(request.uri_, "/index.html");
+  EXPECT_EQ(request.query_["a"], "");
+  EXPECT_EQ(request.headers_["host"], "localhost");
+  EXPECT_EQ(request.headers_["location"], "Yokohama");
+  EXPECT_EQ(request.headers_["language"], "en-US");
+  EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  appendVec(request.buf_, "\r\n567\r\n0\r\n\r\n");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_RECV);
+  std::string str(request.body_.begin(), request.body_.end());
+  EXPECT_EQ(str, "01234567");
+}
+
+TEST_F(test_parseRequest, transferEncodingNG3) {
+  appendVec(request.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "localhost\r\nLocation:\t  \tYokoh");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "ama\r\nlanguage: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "en-US\r\nTransfer-Encoding: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "chunked\r\n\r\n5\r\n01234\r\nA");
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_PARSE_HEADER);
+  EXPECT_EQ(request.method_, "POST");
+  EXPECT_EQ(request.uri_, "/index.html");
+  EXPECT_EQ(request.query_["a"], "");
+  EXPECT_EQ(request.headers_["host"], "localhost");
+  EXPECT_EQ(request.headers_["location"], "Yokohama");
+  EXPECT_EQ(request.headers_["language"], "en-US");
+  EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  appendVec(request.buf_, "\r\n0123456789ab\r\n");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_ERR_BAD_REQUEST);
+  std::string str(request.body_.begin(), request.body_.end());
+  EXPECT_EQ(str, "01234");
+}
+
+TEST_F(test_parseRequest, transferEncodingOK4) {
+  appendVec(request.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "localhost\r\nLocation:\t  \tYokoh");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "ama\r\nlanguage: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "en-US\r\nTransfer-Encoding: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "chunked\r\n\r\n5\r\n01234\r\n3");
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_PARSE_HEADER);
+  EXPECT_EQ(request.method_, "POST");
+  EXPECT_EQ(request.uri_, "/index.html");
+  EXPECT_EQ(request.query_["a"], "");
+  EXPECT_EQ(request.headers_["host"], "localhost");
+  EXPECT_EQ(request.headers_["location"], "Yokohama");
+  EXPECT_EQ(request.headers_["language"], "en-US");
+  EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  appendVec(request.buf_, "\r\n567\r\nFF\r\n123456789abcdef");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  appendVec(request.buf_, "\r\n0\r\n\r\n");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_RECV);
+  std::string str(request.body_.begin(), request.body_.end());
+  EXPECT_EQ(str, "01234567123456789abcdef");
+}

--- a/test/unit_test/ParseRequest/test_parseRequest.cc
+++ b/test/unit_test/ParseRequest/test_parseRequest.cc
@@ -543,3 +543,29 @@ TEST_F(test_parseRequest, transferEncodingNG2) {
   EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
   EXPECT_EQ(request.parseRequest(), REQ_ERR_BAD_REQUEST);
 }
+
+TEST_F(test_parseRequest, transferEncodingOK2) {
+  appendVec(request.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "localhost\r\nLocation:\t  \tYokoh");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "ama\r\nlanguage: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "en-US\r\nTransfer-Encoding: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "chunked\r\n\r\n5\r\n01234\r\n0\r\n\r\n");
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_PARSE_HEADER);
+  EXPECT_EQ(request.method_, "POST");
+  EXPECT_EQ(request.uri_, "/index.html");
+  EXPECT_EQ(request.query_["a"], "");
+  EXPECT_EQ(request.headers_["host"], "localhost");
+  EXPECT_EQ(request.headers_["location"], "Yokohama");
+  EXPECT_EQ(request.headers_["language"], "en-US");
+  EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_CONTINUE_RECV);
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_RECV);
+  std::string str(request.body_.begin(), request.body_.end());
+  EXPECT_EQ(str, "01234");
+}

--- a/test/unit_test/ParseRequest/test_parseRequest.cc
+++ b/test/unit_test/ParseRequest/test_parseRequest.cc
@@ -367,7 +367,8 @@ TEST_F(test_parseRequest, postwithBodyOK1) {
   EXPECT_EQ(request.headers_["language"], "en-US");
   EXPECT_EQ(request.headers_["content-length"], "5");
   EXPECT_EQ(request.parseRequest(), 0);
-  std::string str(request.buf_.begin(), request.buf_.end());
+  // std::string str(request.buf_.begin(), request.buf_.end());
+  std::string str(request.body_.begin(), request.body_.end());
   EXPECT_EQ(str, "01234");
   // EXPECT_EQ(request.body_, "01234");
 }
@@ -391,7 +392,8 @@ TEST_F(test_parseRequest, postwithBodyOK2) {
   EXPECT_EQ(request.headers_["language"], "en-US");
   EXPECT_EQ(request.headers_["content-length"], "5");
   EXPECT_EQ(request.parseRequest(), 0);
-  std::string str(request.buf_.begin(), request.buf_.end());
+  // std::string str(request.buf_.begin(), request.buf_.end());
+  std::string str(request.body_.begin(), request.body_.end());
   EXPECT_EQ(str, "\r\n\r\n\r");
   // EXPECT_EQ(request.body_, "\r\n\r\n\r");
 }
@@ -477,7 +479,8 @@ TEST_F(test_parseRequest, bodyAgain) {
   EXPECT_EQ(request.headers_["language"], "en-US");
   EXPECT_EQ(request.headers_["content-length"], "16");
   EXPECT_EQ(request.parseRequest(), 0);
-  std::string str(request.buf_.begin(), request.buf_.end());
+  // std::string str(request.buf_.begin(), request.buf_.end());
+  std::string str(request.body_.begin(), request.body_.end());
   EXPECT_EQ(str, "0123456789abcdef");
 }
 

--- a/test/unit_test/ParseRequest/test_parseRequest.cc
+++ b/test/unit_test/ParseRequest/test_parseRequest.cc
@@ -522,3 +522,24 @@ TEST_F(test_parseRequest, transferEncodingNG1) {
   EXPECT_EQ(request.headers_["language"], "en-US");
   EXPECT_EQ(request.headers_["transfer-encoding"], "hunked");
 }
+
+TEST_F(test_parseRequest, transferEncodingNG2) {
+  appendVec(request.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "localhost\r\nLocation:\t  \tYokoh");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "ama\r\nlanguage: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "en-US\r\nTransfer-Encoding: \t\t");
+  EXPECT_EQ(request.parseRequest(), 1);
+  appendVec(request.buf_, "chunked\r\n\r\nZZZ\r\n");
+  EXPECT_EQ(request.parseRequest(), REQ_FIN_PARSE_HEADER);
+  EXPECT_EQ(request.method_, "POST");
+  EXPECT_EQ(request.uri_, "/index.html");
+  EXPECT_EQ(request.query_["a"], "");
+  EXPECT_EQ(request.headers_["host"], "localhost");
+  EXPECT_EQ(request.headers_["location"], "Yokohama");
+  EXPECT_EQ(request.headers_["language"], "en-US");
+  EXPECT_EQ(request.headers_["transfer-encoding"], "chunked");
+  EXPECT_EQ(request.parseRequest(), REQ_ERR_BAD_REQUEST);
+}

--- a/test/unit_test/Session/test_checkHTTP413.cc
+++ b/test/unit_test/Session/test_checkHTTP413.cc
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
-/*   Updated: 2021/04/02 14:19:44 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 14:21:46 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -198,6 +198,7 @@ TEST_F(test_checkHTTP413, locationConfigNG) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingOK1) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -219,6 +220,7 @@ TEST_F(test_checkHTTP413, transferEncodingOK1) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingNG1) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -240,6 +242,7 @@ TEST_F(test_checkHTTP413, transferEncodingNG1) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingNG2) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -261,6 +264,7 @@ TEST_F(test_checkHTTP413, transferEncodingNG2) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingOK2) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -287,6 +291,7 @@ TEST_F(test_checkHTTP413, transferEncodingOK2) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingOK3) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -317,6 +322,7 @@ TEST_F(test_checkHTTP413, transferEncodingOK3) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingNG3) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");
@@ -345,6 +351,7 @@ TEST_F(test_checkHTTP413, transferEncodingNG3) {
 }
 
 TEST_F(test_checkHTTP413, transferEncodingOK4) {
+  config.client_max_body_size_ = 42;
   appendVec(session->request_.buf_, "POST /index.html?a HTTP/1.1\r\nHost: ");
   EXPECT_EQ(session->receiveRequest(), 0);
   appendVec(session->request_.buf_, "localhost\r\nLocation:\t  \tYokoh");

--- a/test/unit_test/Session/test_checkHTTP413.cc
+++ b/test/unit_test/Session/test_checkHTTP413.cc
@@ -6,7 +6,7 @@
 /*   By: dhasegaw <dhasegaw@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/31 13:21:25 by dhasegaw         ###   ########.fr       */
+/*   Updated: 2021/04/02 13:38:21 by dhasegaw         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,8 @@ TEST_F(test_checkHTTP413, mainConfigOK) {
   EXPECT_EQ(session->request_.headers_["language"], "en-US");
   EXPECT_EQ(session->request_.headers_["content-length"], "16");
   EXPECT_EQ(session->receiveRequest(), 0);
-  std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  // std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  std::string str(session->request_.body_.begin(), session->request_.body_.end());
   EXPECT_EQ(str, "0123456789abcdef");
 }
 
@@ -106,7 +107,8 @@ TEST_F(test_checkHTTP413, serverConfigOK) {
   EXPECT_EQ(session->request_.headers_["language"], "en-US");
   EXPECT_EQ(session->request_.headers_["content-length"], "16");
   EXPECT_EQ(session->receiveRequest(), 0);
-  std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  // std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  std::string str(session->request_.body_.begin(), session->request_.body_.end());
   EXPECT_EQ(str, "0123456789abcdef");
 }
 
@@ -162,7 +164,8 @@ TEST_F(test_checkHTTP413, locationConfigOK) {
   EXPECT_EQ(session->request_.headers_["language"], "en-US");
   EXPECT_EQ(session->request_.headers_["content-length"], "16");
   EXPECT_EQ(session->receiveRequest(), 0);
-  std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  // std::string str(session->request_.buf_.begin(), session->request_.buf_.end());
+  std::string str(session->request_.body_.begin(), session->request_.body_.end());
   EXPECT_EQ(str, "0123456789abcdef");
 }
 


### PR DESCRIPTION
### transfer-encoding: chunkedの実装

ヤプリ対策を優先しつつ、確認をお願いします。
transfer-encoding: chunkedの実装しました。
transfer-encodingには色々他にもあるのですが、まずはこちらだけ作りました。

**仕様と方針**
- transfer-encodingとcontent-lengthはtransfer-encodingが優先
- transfer-encodingのvalueがchunkedでない && content-lengthがない > HTTP411( length required)
- body内でのchunk size指定が負の数、0-fでないとHTTP400 BAD REQUEST
- chunk size以上のdataはHTTP400 BAD REQUEST
- chunk sizeより小さいデータはエラーなく受け入れる
- 1回のchunkのサイズ上限は一応nginxでも決められる模様。ただし、課題の対応範囲ではなさそうなので、サイズ上限は一旦実装しない。テスターで怒られたら、任意の値でチェックをするようにする。
- 他のエンコーディングはやらなきゃいけなければ付け足す

**変更点**
- Session.cppでtransfer encodingかどうかの判定を追加、以下は全てRequest関係です
- メンバ変数bodyをbufと別立てに（bufはbody作った後にswapテクニックなるもので解放）
[](https://hacknote.jp/archives/26431/)
- メンバ変数flg_chunkedを作り、chunkやるかの管理
- ssize_t parseChunkedBody(size_t pos) チャンクのパース
-  const std::vector<char>& getBody() const; 
-  int getFlgChunked() const;
- ft_atoul_hexbaseをlibftに追加(chunk sizeは16進数）

**テスト**
- unittestのSession, parseRequestに追加
- telnetで実施
```
`GET / HTTP/1.1
host: localhost
transfer-encoding:chunked
content-length:10

3
avc
2
12
0

HTTP/1.1 200 OK
Server: nginDX
Content-Type: text/html
Content-Length: 729`
```

- testerで実行(前回ダメだったPOSTはクリアしたっぽい？）
```
Test POST http://localhost:8888/ with a size of 0

Test HEAD http://localhost:8888/
FATAL ERROR ON LAST TEST: bad status code
```
