### PR TITLE
Dev connection header (keep-alive)

### DIFF
--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 12:30:11 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 15:04:41 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,6 +66,9 @@ std::string Request::bufToString(size_t begin, size_t end) {
 /* compare char literal and a part of buf*/
 int Request::compareBuf(size_t begin, const char* str) {
   size_t len = ft_strlen(str);
+  if (begin + len > buf_.size()) {
+    return 1;
+  }
   for (size_t i = 0; i < len; ++i) {
     if (buf_[i + begin] != str[i]) {
       return 1;

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/09 10:30:07 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 11:09:49 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,22 @@ const std::map<std::string, std::string>& Request::getQuery() const {
 size_t Request::getContentLength() const { return content_length_; }
 const std::vector<char>& Request::getBody() const { return body_; }
 int Request::getFlgChunked() const { return flg_chunked_; };
+
+// reset all for next request
+void Request::resetAll() {
+  parse_progress_ = REQ_BEFORE_PARSE;
+  flg_chunked_ = false;
+  pos_prev_ = 0;
+  content_length_ = 0;
+  chunk_size_ = 0;
+  buf_.clear();
+  body_.clear();
+  header_field_.clear();
+  method_.clear();
+  uri_.clear();
+  query_.clear();
+  headers_.clear();
+}
 
 /* make string from a part of buf*/
 std::string Request::bufToString(size_t begin, size_t end) {

--- a/Request.cpp
+++ b/Request.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 23:36:10 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 11:09:49 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 12:30:11 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,9 +80,11 @@ int Request::compareBuf(size_t begin, const char* str) {
 ** receive request using recv syscall
 **
 ** return values: (negatives are ERRPR)
-** REQ_FIN_PARSE_HEADER 2 //finished parsing header
-** REQ_CONTINUE_RECV 1 //continue to receive
-** REQ_FIN_RECV 0 // finished receiving
+** REQ_FIN_PARSE_HEADER //finished parsing header
+** REQ_CONTINUE_RECV //continue to receive
+** REQ_FIN_RECV // finished receiving
+** REQ_ERR_RECV // error on recv
+** REQ_CLOSE_CON // connection already closed by client
 ** REQ_ERR_HTTP_VERSION -2 //HTTP505
 ** REQ_ERR_LEN_REQUIRED -3 //HTTP411
 ** REQ_ERR_BAD_REQUEST -4 //HTTP400
@@ -97,9 +99,9 @@ int Request::receive(int sock_fd) {
   ret = recv(sock_fd, read_buf, BUFFER_SIZE, 0);
   if (ret < 0) {
     return REQ_ERR_RECV;
+  } else if (ret == 0) {  // if ret == 0, the socket_is closed
+    return REQ_CLOSE_CON;
   }
-  write(1, read_buf, ret);
-  write(1, "\n", 1);
   buf_.insert(buf_.end(), read_buf, read_buf + ret);
 #else
   (void)sock_fd;

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 11:05:10 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 12:25:43 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ extern "C" {
 #define REQ_CONTINUE_RECV 1      // continue to receive
 #define REQ_FIN_RECV 0           // finished receiving
 #define REQ_ERR_RECV -1          // fail syscall of recv
+#define REQ_CLOSE_CON -5         // socket closed by client
 #define REQ_ERR_HTTP_VERSION -2  // HTTP505
 #define REQ_ERR_LEN_REQUIRED -3  // HTTP411
 #define REQ_ERR_BAD_REQUEST -4   // HTTP400

--- a/Request.hpp
+++ b/Request.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 10:51:41 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/09 10:17:41 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 11:05:10 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,8 +70,7 @@ class Request {
   Request();
   virtual ~Request();
 
-  // const std::string& getBuf() const;
-  // const std::vector<char>& getBuf() const;
+  void resetAll();
   const std::string& getMethod() const;
   const std::string& getUri() const;
   const std::map<std::string, std::string>& getHeaders() const;

--- a/Response.hpp
+++ b/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/03 20:22:22 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/31 16:30:05 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 11:00:59 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,7 @@ class Response {
   std::vector<char> body_;
   int send_progress_; // 0: first send, 1: sending header, 2: sending body
   size_t bytes_already_sent_;
+  bool connection_to_close_;
 
   int createCompleteHeader();
 
@@ -42,6 +43,10 @@ class Response {
  public:
   Response();
   virtual ~Response();
+
+  bool isConnectionToClose() const;
+  void setConnectionToClose();
+  void resetAll();
   int addHeader(const std::string& key, const std::string& value);
   int createStatusLine(HTTPStatusCode http_status_);
   int createDefaultErrorResponse(HTTPStatusCode http_status_);

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 12:29:57 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 15:04:53 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -203,6 +203,7 @@ bool Session::checkConnectionTimeOut() const {
 
 // connect to list
 void Session::resetAll() {
+  retry_count_ = 0;
   request_.resetAll();
   response_.resetAll();
 }

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 12:04:11 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 12:29:57 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -223,6 +223,8 @@ int Session::receiveRequest() {
       retry_count_++;
     }
     return 0;
+  } else if (ret == REQ_CLOSE_CON) {
+    return -1;
   }
   retry_count_ = 0;
   return checkReceiveReturn(ret);

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/15 09:36:25 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 10:57:30 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@ class Session {
   Session& operator=(Session const& other);
 
   // connection
+  void resetAll();
   bool checkConnectionTimeOut() const;
   void updateConnectionTime();
 

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/12 23:14:44 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 09:36:25 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ class Session {
 
   int sock_fd_;
   int file_fd_;
+  long time_last_connect_;
   int retry_count_;
   SessionStatus status_;
   const MainConfig& main_config_;
@@ -49,6 +50,10 @@ class Session {
   Session();
   Session(Session const& other);
   Session& operator=(Session const& other);
+
+  // connection
+  bool checkConnectionTimeOut() const;
+  void updateConnectionTime();
 
   // request
   int receiveRequest();

--- a/Webserv.cpp
+++ b/Webserv.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/05 21:48:48 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/24 23:03:15 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 08:52:45 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,7 @@ int Webserv::setToSelect() {
 }
 
 int Webserv::selectAndExecute() {
-  std::cout << "selecting..." << std::endl;
+  // std::cout << "selecting..." << std::endl;
   n_fd_ = select(max_fd_ + 1, &rfds_, &wfds_, NULL, &tv_timeout_);
   if (n_fd_ == -1) {
     std::cout << "[error]: select" << std::endl;

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/01 22:44:35 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/24 08:12:58 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 09:22:35 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,7 @@
 #include "Session.hpp"
 #include "Socket.hpp"
 #include "MainConfig.hpp"
-
-#define SELECT_TIMEOUT_MS 2500
+#include "webserv_settings.hpp"
 
 class Webserv {
  private:

--- a/webserv_settings.hpp
+++ b/webserv_settings.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/29 09:57:21 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/29 09:59:20 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/15 09:21:58 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,5 +14,7 @@
 #define WEBSERV_SETTINGS_HPP
 
 #define WEBSERV_NAME "nginDX"
+#define SELECT_TIMEOUT_MS 500
+#define KEEP_ALIVE_SEC 75
 
 #endif /* WEBSERV_SETTINGS_HPP */


### PR DESCRIPTION
keep-alive実装しました。ご確認願います。

### keep-alive
- 基本的にサーバからコネクションは切らないように変更しました。
- 以下の場合サーバからコネクションを切ります（Sessionをdeleteする）
  - 特定のエラーレスポンスを返す場合（400, 500など）
  - クライアントが`Connection: close` を指定した場合
  - 最後の通信後一定時間（75秒、マクロで設定）経過した場合。

### 付随しての変更点
- クライアントからコネクションを切断された場合（recvシステムコールの返り値が0になる）はSessionをdeleteします。

### 実装メモ
- 最後の通信から何秒立っているかを確認するように、Sessionクラスに変数time_last_connect_と関数updateConnectionTime、checkConnectionTImeoutを追加。
- Responseにコネクションを切るかのフラグconnection_to_close_を追加。
- Session::sock_fd_のclose()位置をデストラクタに変更しました。closeの呼び出し位置がバラつかないようにです。
- 1度レスポンスを送り返したあと、次に備えてRequestとResponseオブジェクトの中身をリセットする関数を追加。
- 不要そうなデバッグ用出力は削除しました。
- 設定っぽい内容（KEEP_ALIVE_SECなどは）webserv_settings.hppに移動しました。

### バグ修正
- Request::compare_buf関数でbuf_.size()を超えてcompareしているところを直しました。
- Unit TESTOKです！（そろそろCI（pushで自動テスト）入れたいですね）

### How to 動作確認

telnetで確認するとコネクション切らずに何回もリクエスト送れるの確認できると思います。`Connection: close` ヘッダを指定するとコネクション切れます。

```
$ telnet localhost 8888
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET / HTTP/1.1
Host: localhost

HTTP/1.1 200 OK
Server: nginDX
Content-Type: text/html
Content-Length: 729
Connection: keep-alive

<!DOCTYPE html>

<html>
（略）
</html>
GET / HTTP/1.1
Host: localhost

HTTP/1.1 200 OK
Server: nginDX
Content-Type: text/html
Content-Length: 729
Connection: keep-alive

<!DOCTYPE html>

<html>
（略）
</html>
GET / HTTP/1.1
Host: localhost
Connection: close

HTTP/1.1 200 OK
Server: nginDX
Content-Type: text/html
Content-Length: 729
Connection: close

<!DOCTYPE html>

<html>
（略）
</html>
Connection closed by foreign host.
```