### PR TITLE
Dev retry after

### DIFF
--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/12 23:32:27 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/18 10:30:04 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,9 +32,11 @@ std::map<std::string, std::string> Session::map_ext_mime_;
 **    - status is initialized SESSION_FOR_CLIENT_RECV first
 */
 
-Session::Session(int sock_fd, const MainConfig& main_config)
+Session::Session(int sock_fd, const MainConfig& main_config,
+                 bool flg_exceed_max_session)
     : sock_fd_(sock_fd),
       retry_count_(0),
+      flg_exceed_max_session_(flg_exceed_max_session),
       status_(SESSION_FOR_CLIENT_RECV),
       main_config_(main_config),
       server_config_(NULL),
@@ -236,6 +238,11 @@ int Session::checkReceiveReturn(int ret) {
 
 // check request, load proper config and start creating response
 void Session::startCreateResponse() {
+  if (flg_exceed_max_session_) {
+    createErrorResponse(HTTP_503);
+    return;
+  }
+
   // case GET
   if ((request_.getMethod() == "GET" && isMethodAllowed(HTTP_GET)) ||
       (request_.getMethod() == "HEAD" && isMethodAllowed(HTTP_HEAD))) {
@@ -336,6 +343,11 @@ void Session::createErrorResponse(HTTPStatusCode http_status) {
 
   // createDefaultErrorResponse
   response_.createDefaultErrorResponse(http_status);
+
+  if (flg_exceed_max_session_) {
+    response_.addHeader("Retry-After",
+                        std::to_string(main_config_.getRetryAfter()));
+  }
   status_ = SESSION_FOR_CLIENT_SEND;
 }
 

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/12 23:14:44 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/18 10:30:51 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,7 @@ class Session {
   int sock_fd_;
   int file_fd_;
   int retry_count_;
+  bool flg_exceed_max_session_;
   SessionStatus status_;
   const MainConfig& main_config_;
   const ServerConfig* server_config_;
@@ -44,7 +45,7 @@ class Session {
   Request request_;
   Response response_;
   CgiHandler cgi_handler_;
-  pid_t cgi_pid_;
+  pid_t cgi_pid_;  // is this needed???
 
   Session();
   Session(Session const& other);
@@ -101,7 +102,8 @@ class Session {
 
  public:
   virtual ~Session();
-  Session(int sock_fd_, const MainConfig& main_config);
+  Session(int sock_fd_, const MainConfig& main_config,
+          bool flg_exceed_max_session);
 
   // getters
   int getSockFd() const;

--- a/Webserv.cpp
+++ b/Webserv.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/05 21:48:48 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/03/24 23:03:15 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/18 10:29:07 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,8 +151,10 @@ int Webserv::selectAndExecute() {
       // accept all incoming connections (rest of n_fd_)
       while (n_fd_-- > 0) {
         int accepted_fd = (*itr)->acceptRequest();
-        if (accepted_fd >= 0) {
-          sessions_.push_back(new Session(accepted_fd, config_));
+        if (sessions_.size() >= static_cast<size_t>(config_.getMaxSessions())) {
+          sessions_.push_back(new Session(accepted_fd, config_, true));
+        } else if (accepted_fd >= 0) {
+          sessions_.push_back(new Session(accepted_fd, config_, false));
         }
       }
     }

--- a/configfiles/has_max_sessions.conf
+++ b/configfiles/has_max_sessions.conf
@@ -1,0 +1,10 @@
+# toriaezu
+root ./html;
+max_sessions 1;
+retry_after 42;
+
+# server
+server {
+    listen 8888;
+    index index.html;
+}

--- a/docs/doc_config.md
+++ b/docs/doc_config.md
@@ -383,7 +383,7 @@ main
 
 
 ### retry_afterディレクティブ
-`429 Too Many Requests` のレスポンスを返す際に、`Retry-After` ヘッダで指定する値を入力する。秒数で指定する。
+`503 Service Unavaileble`のレスポンスを返す際に、`Retry-After` ヘッダで指定する値を入力する。秒数で指定する。
 
 (nginxにない)
 


### PR DESCRIPTION
max_sessionsとretry_afterディレクティブを反映するようにしました。ご確認をお願いいたします！
これで一応Retry-Afterヘッダに対応してます。

### 内容
- Sessionを追加する際にmax_sessions_ディレクティブを確認
- Sessionにflg_exceed_max_session_を導入
- flt_exceed_max_session_を超えていたらRequestの内容によらず、503をRetry-Afterヘッダつきで返すようにしました
- Retry-Afterヘッダの数値はRetry-Afterディレクティブ通りです
- docも修正（retry_afterヘッダの説明が503になってなかった）

### 動作確認
telnetで繋ぎっぱなしにしといて、もう一つのセッションを作ろうとすると503が返ります。

config (configfiles/has_max_sessions.conf)
```
root ./html;
max_sessions 1;
retry_after 42;

# server
server {
    listen 8888;
    index index.html;
}
```

telnetで一つsessionを立てている状態で、
```
$ curl -i localhost:8888
HTTP/1.1 503 Service Unavailable
Server: nginDX
Content-Type: text/html
Retry-After: 42
Content-Length: 186
Connection: close

<html>
<head><title>503 Service Unavailable</title></ head>
<body bgcolor = "white">
<center><h1>503 Service Unavailable</h1></center>
<hr><center> nginDX </center>
</body></html>
```