### PR TITLE
Dev language related header and checking

### DIFF
--- a/CommonConfigStore.cpp
+++ b/CommonConfigStore.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/17 18:58:46 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/20 22:56:58 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 19:28:54 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,9 @@ const std::list<std::string>& CommonConfigStore::getCgiExtension() const {
 
 const std::string& CommonConfigStore::getCharset() const { return charset_; }
 
-const std::string& CommonConfigStore::getLanguage() const { return language_; }
+const std::list<std::string>& CommonConfigStore::getLanguage() const {
+  return language_;
+}
 
 const std::string& CommonConfigStore::getBaseAuth() const { return base_auth_; }
 
@@ -159,18 +161,20 @@ void CommonConfigStore::parseCharset(const std::list<std::string>& settings) {
   } else if (settings.size() != 1) {
     throw std::runtime_error("charset: invalid number of setting");
   }
-  // need to check charset name???
   charset_ = settings.front();
 }
 
 void CommonConfigStore::parseLanguage(const std::list<std::string>& settings) {
   if (!language_.empty()) {
     throw std::runtime_error("language: directive duplicated");
-  } else if (settings.size() != 1) {
+  } else if (settings.empty()) {
     throw std::runtime_error("language: invalid number of setting");
   }
-  // need to check language name???
-  language_ = settings.front();
+  // check and store language name
+  for (std::list<std::string>::const_iterator itr = settings.begin();
+       itr != settings.end(); ++itr) {
+    language_.push_back(*itr);
+  }
 }
 
 void CommonConfigStore::parseBaseAuth(const std::list<std::string>& settings) {

--- a/CommonConfigStore.hpp
+++ b/CommonConfigStore.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 17:40:46 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/28 12:17:47 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 18:38:46 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ class CommonConfigStore {
   bool flg_autoindex_set_;                // true if autoindex already set
   std::list<std::string> cgi_extension_;  // cgi_extension directive
   std::string charset_;                   // charset directive
-  std::string language_;                  // launuage directive
+  std::list<std::string> language_;       // launuage directive
   std::string base_auth_;                 // base_auth directive
   std::list<std::string>
       auth_basic_user_file_;            // auth_basic_userfile directive
@@ -85,7 +85,7 @@ class CommonConfigStore {
   bool getAutoIndex() const;
   const std::list<std::string>& getCgiExtension() const;
   const std::string& getCharset() const;
-  const std::string& getLanguage() const;
+  const std::list<std::string>& getLanguage() const;
   const std::string& getBaseAuth() const;
   const std::list<std::string>& getAuthBasicUserFile() const;
   const unsigned long& getClientMaxBodySize() const;

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/22 08:27:38 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 21:02:24 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -617,6 +617,7 @@ int Session::addResponseHeaderOfFile(const std::string& filepath,
   response_.createStatusLine(HTTP_200);
 
   addContentTypeHeader(filepath, mime_type);
+  addContentLanguageHeader();
 
   // last modified
   struct stat pathstat;
@@ -727,6 +728,24 @@ void Session::addContentTypeHeader(const std::string& filepath,
   response_.addHeader("Content-Type", content_type);
 }
 
+void Session::addContentLanguageHeader() {
+  const std::list<std::string>& languages = findLanguage();
+  if (languages.empty()) {
+    return;
+  }
+
+  std::string content_language;
+  for (std::list<std::string>::const_iterator itr = languages.begin();
+       itr != languages.end(); ++itr) {
+    if (!content_language.empty()) {
+      content_language.append(", ");
+    }
+    content_language.append(*itr);
+  }
+
+  response_.addHeader("Content-Language", content_language);
+}
+
 std::string Session::findCharset() const {
   if (location_config_ && !location_config_->getCharset().empty()) {
     return location_config_->getCharset();
@@ -735,6 +754,16 @@ std::string Session::findCharset() const {
     return server_config_->getCharset();
   }
   return main_config_.getCharset();
+}
+
+const std::list<std::string>& Session::findLanguage() const {
+  if (location_config_ && !location_config_->getLanguage().empty()) {
+    return location_config_->getLanguage();
+  }
+  if (server_config_ && !server_config_->getLanguage().empty()) {
+    return server_config_->getLanguage();
+  }
+  return main_config_.getLanguage();
 }
 
 // find requested file

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/23 09:15:53 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/23 09:26:21 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -583,8 +583,8 @@ void Session::startReadingFromFile(const std::string& filepath) {
   // get mime type
   std::string mime_type = mimeType(filepath);
 
-  // check charset
-  if (!isCharsetAccepted(mime_type)) {
+  // check charset and language
+  if (!isCharsetAccepted(mime_type) || !isLanguageAccepted()) {
     createErrorResponse(HTTP_406);
     return;
   }

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/22 08:27:47 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 19:56:59 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,10 +82,12 @@ class Session {
   std::string mimeType(const std::string& filepath) const;
   bool isCharsetAccepted(const std::string& mime_type) const;
   int addResponseHeaderOfFile(const std::string& filepath,
-                               const std::string& mime_type);
+                              const std::string& mime_type);
   void addContentTypeHeader(const std::string& filepath,
                             const std::string& mime_type);
+  void addContentLanguageHeader();
   std::string findCharset() const;
+  const std::list<std::string>& findLanguage() const;
   const std::string& findRoot() const;
   bool isIndex(const std::string& filename) const;
   int readFromFile();

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/24 08:49:03 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/24 08:58:08 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,7 +93,6 @@ class Session {
   void addContentLanguageHeader();
   std::string findCharset() const;
   const std::list<std::string>& findLanguage() const;
-  const std::string& findRoot() const;
   bool isIndex(const std::string& filename) const;
   int readFromFile();
 
@@ -145,7 +144,6 @@ class Session {
   int checkSelectedAndExecute(fd_set* rfds, fd_set* wfds);
   int checkReceiveReturn(int ret);
 
-  //read from file
   const std::string& findRoot() const;
 };
 

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/22 19:56:59 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 21:28:31 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,6 +81,7 @@ class Session {
   std::string findFile(const std::string& uri) const;
   std::string mimeType(const std::string& filepath) const;
   bool isCharsetAccepted(const std::string& mime_type) const;
+  bool isLanguageAccepted() const;
   int addResponseHeaderOfFile(const std::string& filepath,
                               const std::string& mime_type);
   void addContentTypeHeader(const std::string& filepath,

--- a/configfiles/has_language.conf
+++ b/configfiles/has_language.conf
@@ -5,5 +5,5 @@ root ./html;
 server {
     listen 8888;
     index index.html;
-    language ja-JP en-US;
+    language ja en-US;
 }

--- a/configfiles/has_language.conf
+++ b/configfiles/has_language.conf
@@ -5,5 +5,5 @@ root ./html;
 server {
     listen 8888;
     index index.html;
-    language ja;
+    language ja-JP en-US;
 }

--- a/configfiles/has_language.conf
+++ b/configfiles/has_language.conf
@@ -1,0 +1,9 @@
+# toriaezu
+root ./html;
+
+# server
+server {
+    listen 8888;
+    index index.html;
+    language ja;
+}

--- a/docs/doc_config.md
+++ b/docs/doc_config.md
@@ -324,16 +324,16 @@ main, server, location
 ### languageディレクティブ
 リソースの言語を1つ指定することができる。
 
-これを指定することによりweb-servは以下を行う。
+これを指定することによりwebservは以下を行う。
 - リクエスト中に含まれる`Accept-Language`ヘッダーの内容に合致しているか確認し、合致していない場合、`406 Not-Acceptable` を返す。
-- レスポンスの`Content-Type` 及び、`Content-Langage`ヘッダ内の`lang` の内容を設定する。（ただし、CGIについては出力中に`Content-Type`ヘッダの記述が無い場合に限る）
+- レスポンスの`Content-Type` 及び、`Content-Langage`ヘッダ内の`lang` の内容を設定する。
 
 重複は不可。子contextで指定された場合は上書きする。
 
 https://www.nginx.com/resources/wiki/modules/accept_language/
 
 #### 指定できるlanguage
-（追記予定）
+形式は問わないが空白文字を含まないこと。複数指定可能。
 
 #### 文法
 

--- a/test/unit_test/CommonConfigStore/test_parseDirective.cc
+++ b/test/unit_test/CommonConfigStore/test_parseDirective.cc
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/21 09:16:34 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 19:11:26 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,7 @@ TEST_F(test_parseDirective, language) {
   EXPECT_THROW(store.parseDirective("language", settings), std::runtime_error);
   settings.push_back("ja-JP");
   EXPECT_TRUE(store.parseDirective("language", settings));
-  EXPECT_EQ(store.getLanguage(), "ja-JP");
+  EXPECT_EQ(store.getLanguage().front(), "ja-JP");
 }
 
 TEST_F(test_parseDirective, base_auth) {

--- a/test/unit_test/CommonConfigStore/test_parseLanguage.cc
+++ b/test/unit_test/CommonConfigStore/test_parseLanguage.cc
@@ -6,14 +6,14 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
-/*   Updated: 2021/03/21 09:16:37 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/22 19:29:11 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #define UNIT_TEST
 
-#include "gtest.h"
 #include "CommonConfigStore.hpp"
+#include "gtest.h"
 
 class test_parseLanguage : public ::testing::Test {
  protected:
@@ -28,10 +28,50 @@ class test_parseLanguage : public ::testing::Test {
   virtual void TearDown() {}
 };
 
-TEST_F(test_parseLanguage, normal) {
-  settings.push_back("utf-8");
+TEST_F(test_parseLanguage, normalOne_ja) {
+  settings.push_back("ja");
   EXPECT_NO_THROW(store.parseLanguage(settings));
-  EXPECT_EQ(store.getLanguage(), settings.front());
+  std::list<std::string>::const_iterator itr_settings = settings.begin();
+  std::list<std::string>::const_iterator itr_language =
+      store.getLanguage().begin();
+  while (itr_settings != settings.end()) {
+    EXPECT_EQ(*itr_settings, *itr_language);
+    ++itr_settings;
+    ++itr_language;
+  }
+  EXPECT_EQ(itr_language, store.getLanguage().end());
+}
+
+TEST_F(test_parseLanguage, normalOne_ja_JP) {
+  settings.push_back("ja-JP");
+  EXPECT_NO_THROW(store.parseLanguage(settings));
+  std::list<std::string>::const_iterator itr_settings = settings.begin();
+  std::list<std::string>::const_iterator itr_language =
+      store.getLanguage().begin();
+  while (itr_settings != settings.end()) {
+    EXPECT_EQ(*itr_settings, *itr_language);
+    ++itr_settings;
+    ++itr_language;
+  }
+  EXPECT_EQ(itr_language, store.getLanguage().end());
+}
+
+TEST_F(test_parseLanguage, normalFive) {
+  settings.push_back("ja-JP");
+  settings.push_back("en-GB");
+  settings.push_back("en-US");
+  settings.push_back("es");
+  settings.push_back("zn");
+  EXPECT_NO_THROW(store.parseLanguage(settings));
+  std::list<std::string>::const_iterator itr_settings = settings.begin();
+  std::list<std::string>::const_iterator itr_language =
+      store.getLanguage().begin();
+  while (itr_settings != settings.end()) {
+    EXPECT_EQ(*itr_settings, *itr_language);
+    ++itr_settings;
+    ++itr_language;
+  }
+  EXPECT_EQ(itr_language, store.getLanguage().end());
 }
 
 TEST_F(test_parseLanguage, emptySetting) {
@@ -44,8 +84,10 @@ TEST_F(test_parseLanguage, emptySetting) {
   EXPECT_TRUE(flg_thrown);
 }
 
+// no need to specify format
+/*
 TEST_F(test_parseLanguage, duplicateSetting) {
-  settings.push_back("utf-8");
+  settings.push_back("ja");
   try {
     store.parseLanguage(settings);
     store.parseLanguage(settings);
@@ -56,14 +98,81 @@ TEST_F(test_parseLanguage, duplicateSetting) {
   EXPECT_TRUE(flg_thrown);
 }
 
-TEST_F(test_parseLanguage, settingInvalidNumber) {
-  settings.push_back("utf-8");
-  settings.push_back("utf-8");
+TEST_F(test_parseLanguage, invalidFormat1) {
+  settings.push_back("ja");
+  settings.push_back("j");
+  settings.push_back("en");
   try {
     store.parseLanguage(settings);
   } catch (const std::runtime_error& e) {
-    EXPECT_STREQ(e.what(), "language: invalid number of setting");
+    EXPECT_STREQ(e.what(), "language: invalid value \"j\"");
     flg_thrown = true;
   }
   EXPECT_TRUE(flg_thrown);
 }
+
+TEST_F(test_parseLanguage, invalidFormat2) {
+  settings.push_back("ja");
+  settings.push_back("j-");
+  settings.push_back("en");
+  try {
+    store.parseLanguage(settings);
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "language: invalid value \"j-\"");
+    flg_thrown = true;
+  }
+  EXPECT_TRUE(flg_thrown);
+}
+
+TEST_F(test_parseLanguage, invalidFormat3) {
+  settings.push_back("ja");
+  settings.push_back("ja-");
+  settings.push_back("en");
+  try {
+    store.parseLanguage(settings);
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "language: invalid value \"ja-\"");
+    flg_thrown = true;
+  }
+  EXPECT_TRUE(flg_thrown);
+}
+
+TEST_F(test_parseLanguage, invalidFormat4) {
+  settings.push_back("ja");
+  settings.push_back("ja-");
+  settings.push_back("en");
+  try {
+    store.parseLanguage(settings);
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "language: invalid value \"ja-\"");
+    flg_thrown = true;
+  }
+  EXPECT_TRUE(flg_thrown);
+}
+
+TEST_F(test_parseLanguage, invalidFormat5) {
+  settings.push_back("ja");
+  settings.push_back("ja-JPP");
+  settings.push_back("en");
+  try {
+    store.parseLanguage(settings);
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "language: invalid value \"ja-JPP\"");
+    flg_thrown = true;
+  }
+  EXPECT_TRUE(flg_thrown);
+}
+
+TEST_F(test_parseLanguage, invalidFormat) {
+  settings.push_back("ja");
+  settings.push_back("JAPAN");
+  settings.push_back("en");
+  try {
+    store.parseLanguage(settings);
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "language: invalid value \"JAPAN\"");
+    flg_thrown = true;
+  }
+  EXPECT_TRUE(flg_thrown);
+}
+*/

--- a/test/unit_test/Session/Makefile
+++ b/test/unit_test/Session/Makefile
@@ -6,7 +6,7 @@
 #    By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/03/09 10:22:35 by dnakano           #+#    #+#              #
-#    Updated: 2021/04/20 15:04:46 by dnakano          ###   ########.fr        #
+#    Updated: 2021/04/23 08:42:32 by dnakano          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,7 +40,8 @@ TESTSRCNAME	:=	test_main.cc \
 				test_checkHTTP413.cc \
 				test_mapMime.cc \
 				test_getFileExtension.cc \
-				test_isCharsetAccepted.cc
+				test_isCharsetAccepted.cc \
+				test_isLanguageAccepted.cc
 TESTSRCDIR	:=	.
 
 ### config ###

--- a/test/unit_test/Session/test_isLanguageAccepted.cc
+++ b/test/unit_test/Session/test_isLanguageAccepted.cc
@@ -1,0 +1,386 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   test_isLanguageAccepted.cc                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
+/*   Updated: 2021/04/23 09:17:24 by dnakano          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#define UNIT_TEST
+
+#include "MainConfig.hpp"
+#include "Session.hpp"
+#include "gtest.h"
+
+class test_isLanguageAccepted : public ::testing::Test {
+ protected:
+  MainConfig config;
+  Session* session;
+virtual void SetUp() {
+    session = new Session(0, config);
+    session->request_.headers_["host"] = "localhost:8080";
+  }
+
+  // 各ケース共通の後処理を書く
+  virtual void TearDown() { delete session; }
+};
+
+TEST_F(test_isLanguageAccepted, only_ja_vs_ja) {
+  config.language_.push_back("ja");
+  session->request_.headers_["accept-language"] = "ja";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_vs_ja_en_es) {
+  config.language_.push_back("ja");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_vs_ja_en_es) {
+  config.language_.push_back("en");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_vs_ja_JP) {
+  config.language_.push_back("ja");
+  session->request_.headers_["accept-language"] = "ja-JP";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("ja");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("en");
+  session->request_.headers_["accept-language"] = "ja-JP  , en-US, es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_es_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("es");
+  session->request_.headers_["accept-language"] = "ja-JP  , en-US , es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("ja");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("en");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_es_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("es");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8  , en-US  ;q=0.8  , es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+///////
+
+
+TEST_F(test_isLanguageAccepted, only_ja_JP_vs_ja) {
+  config.language_.push_back("ja-JP");
+  session->request_.headers_["accept-language"] = "ja";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_JP_vs_ja_en_es) {
+  config.language_.push_back("ja-JP");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_US_vs_ja_en_es) {
+  config.language_.push_back("en-US");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_es_vs_ja_en_es) {
+  config.language_.push_back("es-US");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_JP_vs_ja_JP) {
+  config.language_.push_back("ja-JP");
+  session->request_.headers_["accept-language"] = "ja-JP";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_JP_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("ja-JP");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_US_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("en-US");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_es_US_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("es-US");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_JP_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("ja-JP");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_US_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("en-US");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_es_US_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("es-US");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+/// case won't match
+
+TEST_F(test_isLanguageAccepted, only_ko_vs_ja) {
+  config.language_.push_back("ko");
+  session->request_.headers_["accept-language"] = "ja";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ko_vs_ja_en_es) {
+  config.language_.push_back("ko");
+  session->request_.headers_["accept-language"] = "ja, en, es";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] = "ja-JP";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] = "ja-JP";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP_en_US_es_US) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP_en_US_es_US_with_q) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1";
+  EXPECT_FALSE(session->isLanguageAccepted());
+}
+
+/// case won't match will match with *
+
+TEST_F(test_isLanguageAccepted, only_ko_vs_ja_wild) {
+  config.language_.push_back("ko");
+  session->request_.headers_["accept-language"] = "ja, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ko_vs_ja_en_es_wild) {
+  config.language_.push_back("ko");
+  session->request_.headers_["accept-language"] = "ja, en, es, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP_wild) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] = "ja-JP, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP_wild) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] = "ja-JP, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP_en_US_es_US_wild) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP_en_US_es_US_wild) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] = "ja-JP, en-US, es-US, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_ja_US_vs_ja_JP_en_US_es_US_wild_with_q) {
+  config.language_.push_back("ja-US");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+TEST_F(test_isLanguageAccepted, only_en_JP_vs_ja_JP_en_US_es_US_wild_with_q) {
+  config.language_.push_back("en-JP");
+  session->request_.headers_["accept-language"] =
+      "ja-JP;q=0.8, en-US;q=0.8,es-US;q=0.1, *";
+  EXPECT_TRUE(session->isLanguageAccepted());
+}
+
+// TEST_F(test_isLanguageAccepted, onlyOneBig) {
+//   config.charset_ = "UTF-8";
+//   session->request_.headers_["accept-language"] = "UTF-8";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneSmallBig) {
+//   config.charset_ = "UTF-8";
+//   session->request_.headers_["accept-language"] = "utf-8";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneBigSmall) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "UTF-8";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneMixed) {
+//   config.charset_ = "UtF-8";
+//   session->request_.headers_["accept-language"] = "uTf-8";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff1) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "utf-";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff2) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "utf-82";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff3) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "utf-9";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff4) {
+//   config.charset_ = "utf-";
+//   session->request_.headers_["accept-language"] = "utf-8";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff5) {
+//   config.charset_ = "utf-9";
+//   session->request_.headers_["accept-language"] = "utf-8";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneDiff6) {
+//   config.charset_ = "utf-82";
+//   session->request_.headers_["accept-language"] = "utf-8";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, onlyOneWild) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "*";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoFirst) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] = "utf-8, iso-8859-1;q=0.5";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoSecond) {
+//   config.charset_ = "iso-8859-1";
+//   session->request_.headers_["accept-language"] = "utf-8, iso-8859-1;q=0.5";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardFirst) {
+//   config.charset_ = "utf-8";
+//   session->request_.headers_["accept-language"] =
+//       "utf-8, iso-8859-1;q=0.5, *;q=0.1";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardSecond) {
+//   config.charset_ = "iso-8859-1";
+//   session->request_.headers_["accept-language"] =
+//       "utf-8, iso-8859-1;q=0.5, *;q=0.1";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardWild) {
+//   config.charset_ = "shift-jis";
+//   session->request_.headers_["accept-language"] =
+//       "utf-8, iso-8859-1;q=0.5, *;q=0.1";
+//   EXPECT_TRUE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardShouldNotMatch1) {
+//   config.charset_ = "q=0.5";
+//   session->request_.headers_["accept-language"] = "utf-8, iso-8859-1;q=0.5";
+//   EXPECT_FALSE(session->isLanguageAccepted("text/html"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardShouldNotMatchJson) {
+//   config.charset_ = "q=0.5";
+//   session->request_.headers_["accept-language"] = "utf-8, iso-8859-1;q=0.5";
+//   EXPECT_FALSE(session->isLanguageAccepted("application/json"));
+// }
+
+// TEST_F(test_isLanguageAccepted, multiTwoWildCardShouldNotMatch1ButNotText) {
+//   config.charset_ = "q=0.5";
+//   session->request_.headers_["accept-language"] = "utf-8, iso-8859-1;q=0.5";
+//   EXPECT_TRUE(session->isLanguageAccepted("application/octed-stream"));
+// }19


### PR DESCRIPTION
Language周り作りました。ご確認をお願いいたします！

### language ディレクティブ修正
- 複数の値を入力できるように変更
- 値のバリデーションは特に入れていません。
- 仕様書（doc/doc_config.md）も変更しています。

### レスポンスにContent-Launguageヘッダ追加
- languageディレクティブが指定されていた場合に、Content-Languageヘッダを追加
- 複数の場合はカンマ区切りで入ります。（https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Language）

### リクエストのAccept-Languageヘッダの確認を追加
- リクエスト内部のAccept-Languageヘッダをリスペクトするように変更しました。
- languageディレクティブが指定されている場合、Accept-Languageヘッダと照合するようにしています。
- マッチしない場合、406 Not Acceptableが返るようにしています。
- マッチするパターン（オレオレ仕様です）
  - language: `ja` vs Acctept-Language: `ja`
  - language: `en` vs Acctept-Language: `en-US`
  - language: `en-US` vs Acctept-Language: `en`
  - language: `en-US` vs Acctept-Language: `en-US`
- マッチしないパターン
  - language: `en` vs Acctept-Language: `ja`
  - language: `en-GB` vs Acctept-Language: `en-US`
- Session::isLanguageAccepted関数で判定しています。
  - unitテスト書いています。

### 動作確認
`$ ./nginDX configfiles/has_language.conf` で走らせてください！

```
$ curl -i localhost:8888
HTTP/1.1 200 OK
Server: nginDX
Date: Fri, 23 Apr 2021 00:45:29 GMT
Content-Type: text/html
Content-Language: ja, en-US
Last-Modified: Mon, 29 Mar 2021 07:30:18 GMT
Content-Length: 729
Connection: keep-alive

<!DOCTYPE html>
（略）
```

```
$ curl -i -H "Accept-Language: ja" localhost:8888  
HTTP/1.1 200 OK
Server: nginDX
Date: Fri, 23 Apr 2021 00:46:01 GMT
Content-Type: text/html
Content-Language: ja, en-US
Last-Modified: Mon, 29 Mar 2021 07:30:18 GMT
Content-Length: 729
Connection: keep-alive

<!DOCTYPE html>
（略）
```

```
$ curl -i -H "Accept-Language: en-US" localhost:8888
HTTP/1.1 200 OK
Server: nginDX
Date: Fri, 23 Apr 2021 00:46:28 GMT
Content-Type: text/html
Content-Language: ja, en-US
Last-Modified: Mon, 29 Mar 2021 07:30:18 GMT
Content-Length: 729
Connection: keep-alive

<!DOCTYPE html>
（略）
```

```
$ curl -i -H "Accept-Language: ko" localhost:8888
HTTP/1.1 406 Not Acceptable
Server: nginDX
Date: Fri, 23 Apr 2021 00:46:52 GMT
Content-Type: text/html
Content-Length: 176
Connection: keep-alive

<html>
<head><title>406 Not Acceptable</title></ head>
<body bgcolor = "white">
<center><h1>406 Not Acceptable</h1></center>
<hr><center> nginDX </center>
</body></html>
```