### PR TITLE
Mod location filepath

### DIFF
--- a/CommonConfigStore.cpp
+++ b/CommonConfigStore.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/17 18:58:46 by dnakano           #+#    #+#             */
-/*   Updated: 2021/04/22 19:28:54 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 07:44:42 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -244,7 +244,8 @@ void CommonConfigStore::parseLimitExcept(
   for (std::list<std::string>::const_iterator itr = settings.begin();
        itr != settings.end(); ++itr) {
     if (*itr == "GET") {
-      limit_except_ |= (HTTP_GET | HTTP_HEAD);
+      // limit_except_ |= (HTTP_GET | HTTP_HEAD);
+      limit_except_ |= HTTP_GET;
     } else if (*itr == "HEAD") {
       limit_except_ |= HTTP_HEAD;
     } else if (*itr == "PUT") {

--- a/LocationConfig.hpp
+++ b/LocationConfig.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/01 23:59:30 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/06 14:47:03 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 08:12:50 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,11 @@
 
 class LocationConfig : public CommonConfigStore,
                        public ServerLocationConfigStore {
+#ifdef UNIT_TEST
+ public:
+#else
  private:
+#endif
   std::string route_;  // location path
 
  public:

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/27 09:29:31 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 09:56:55 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -1381,8 +1381,6 @@ int Session::readFromCgi() {
       // close connection and make error responce
       std::cout << "[error] close connection to CGI process" << std::endl;
       close(cgi_handler_.getOutputFd());
-      // response_buf_ = "500 internal server error";  // TODO: make response
-      // func
 
       // kill the process on error (if failed kill, we can do nothing...)
       if (kill(cgi_handler_.getPid(), SIGKILL) == -1) {
@@ -1390,7 +1388,7 @@ int Session::readFromCgi() {
       }
 
       // to send error response to client
-      status_ = SESSION_FOR_CLIENT_SEND;
+      createErrorResponse(HTTP_500);
       return 0;
     }
     retry_count_++;

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/27 08:16:59 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 09:09:13 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -330,7 +330,7 @@ void Session::startCreateResponseToGet() {
   }
 
   // find file
-  filepath = findRoot() + request_.getUri();
+  filepath = findRoot() + getUriFromLocation();
   if (stat(filepath.c_str(), &pathstat) == -1) {
     createErrorResponse(HTTP_404);
     return;
@@ -349,7 +349,7 @@ void Session::startCreateResponseToGet() {
     if (res.empty()) {
       startDirectoryListing(filepath);
     } else {
-      if (*(filepath.end() - 1) != '/' && res[0] != '/') {
+      if (*(filepath.rbegin()) != '/' && res[0] != '/') {
         filepath.append("/");  // append "/" if missing
       }
       startReadingFromFile(filepath + res);

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/27 09:09:13 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 09:29:31 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -320,7 +320,7 @@ void Session::startCreateResponseToGet() {
   // check path includes cgi extension
   const std::string cgiuri = findCgiPathFromUri();
   if (!cgiuri.empty()) {
-    filepath = findRoot() + cgiuri;
+    filepath = findRoot() + getUriFromLocation(cgiuri);
     if (filepath.empty()) {
       createErrorResponse(HTTP_404);
     } else {
@@ -359,15 +359,18 @@ void Session::startCreateResponseToGet() {
   createErrorResponse(HTTP_404);
 }
 
-std::string Session::getUriFromLocation() const {
+std::string Session::getUriFromLocation(std::string uri) const {
+  if (uri.empty()) {
+    uri = request_.getUri();
+  }
   if (!location_config_) {
-    return request_.getUri();
+    return uri;
   }
   std::string res;
   if (*location_config_->getRoute().rbegin() == '/') {
-    res = request_.getUri().substr(location_config_->getRoute().length() - 1);
+    res = uri.substr(location_config_->getRoute().length() - 1);
   } else {
-    res = request_.getUri().substr(location_config_->getRoute().length());
+    res = uri.substr(location_config_->getRoute().length());
   }
   return res;
 }

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,12 +6,11 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/24 23:32:29 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 08:16:59 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Session.hpp"
-#include "CgiParams.hpp"
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -20,9 +19,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
+#include "CgiParams.hpp"
 #include "webserv_settings.hpp"
 #include "webserv_utils.hpp"
 
@@ -357,6 +357,19 @@ void Session::startCreateResponseToGet() {
     return;
   }
   createErrorResponse(HTTP_404);
+}
+
+std::string Session::getUriFromLocation() const {
+  if (!location_config_) {
+    return request_.getUri();
+  }
+  std::string res;
+  if (*location_config_->getRoute().rbegin() == '/') {
+    res = request_.getUri().substr(location_config_->getRoute().length() - 1);
+  } else {
+    res = request_.getUri().substr(location_config_->getRoute().length());
+  }
+  return res;
 }
 
 void Session::startCreateResponseToPost() {
@@ -1461,13 +1474,13 @@ ssize_t Session::parseReadBuf(const char* read_buf, ssize_t n) {
         continue;
       }
       /* add header */
-      response_.addHeader(itr->first, itr->second); 
+      response_.addHeader(itr->first, itr->second);
     }
     /* Parse OK then return the pos of end of header */
     return i + ret;
   }
   /* case no valid header */
-  return -1;  
+  return -1;
 }
 
 /*

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/24 23:32:44 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 08:15:51 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -129,6 +129,8 @@ class Session {
   // respond to options header
   void startCreateResponseToOptions();
   void createAllowHeader();
+
+  std::string getUriFromLocation() const;
 
  public:
   virtual ~Session();

--- a/Session.hpp
+++ b/Session.hpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/02 01:32:00 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/04/27 08:15:51 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/04/27 09:29:19 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -130,7 +130,7 @@ class Session {
   void startCreateResponseToOptions();
   void createAllowHeader();
 
-  std::string getUriFromLocation() const;
+  std::string getUriFromLocation(std::string uri = "") const;
 
  public:
   virtual ~Session();

--- a/configfiles/has_location.conf
+++ b/configfiles/has_location.conf
@@ -7,7 +7,9 @@ server {
     index index.html;
     
     #location
-    location /fuga/ {
+    location /directory/ {
+        cgi_extension cgi;
+        root ./html/fuga;
         index fuga.html;
     }
 }

--- a/html/fuga/sample.cgi
+++ b/html/fuga/sample.cgi
@@ -1,0 +1,97 @@
+#!/usr/bin/perl
+# 上の１行の前には空行も空白文字もはいらないようにしてください。
+# perlのパス名はプロバイダや環境に合わせて変更してください。
+
+#
+# CGIのヘッダを書き出します。通常は text/html を指定します。
+#
+print "Content-Type: text/html; charset=utf-8\n";
+print "Status: 777 Lucky\n";
+print "\n";
+
+#
+# HTMLを書き出します。
+# "～\n" の ～ の部分に HTML を記述しますが、ダブルクォーテーション( " )
+# を用いる際は " の代わりに ' を用いるか、\" のように、バックスラッシュ( \ )
+# を前に置いてください。
+#
+print "<HTML>\n";
+print "<HEAD>\n";
+print "<TITLE>CGI TEST</TITLE>\n";
+print "</HEAD>\n";
+print "<BODY BGCOLOR='#FFFFFF' TEXT='#000000'>\n";
+print "<XMP>\n";
+
+#
+# wwwperl.cgi?引数1+引数2 で指定したコマンド引数を書き出します。
+#
+print "=================================\n";
+print "コマンド引数\n";
+print "=================================\n";
+for ($i = 0; $i <= $#ARGV; $i++) {
+	print "ARGV[$i] = [ $ARGV[$i] ]\n";
+}
+print "\n";
+
+#
+# CGIスクリプトが参照可能な環境変数を書き出します。
+#
+print "=================================\n";
+print "環境変数\n";
+print "=================================\n";
+print "AUTH_TYPE = [ $ENV{'AUTH_TYPE'} ]\n";
+print "CONTENT_LENGTH = [ $ENV{'CONTENT_LENGTH'} ]\n";
+print "CONTENT_TYPE = [ $ENV{'CONTENT_TYPE'} ]\n";
+print "GATEWAY_INTERFACE = [ $ENV{'GATEWAY_INTERFACE'} ]\n";
+print "PATH_INFO = [ $ENV{'PATH_INFO'} ]\n";
+print "PATH_TRANSLATED = [ $ENV{'PATH_TRANSLATED'} ]\n";
+print "QUERY_STRING = [ $ENV{'QUERY_STRING'} ]\n";
+print "REMOTE_ADDR = [ $ENV{'REMOTE_ADDR'} ]\n";
+print "REMOTE_IDENT = [ $ENV{'REMOTE_IDENT'} ]\n";
+print "REMOTE_USER = [ $ENV{'REMOTE_USER'} ]\n";
+print "REQUEST_METHOD = [ $ENV{'REQUEST_METHOD'} ]\n";
+print "REQUEST_URI = [ $ENV{'REQUEST_URI'} ]\n";
+print "SCRIPT_NAME = [ $ENV{'SCRIPT_NAME'} ]\n";
+print "SERVER_NAME = [ $ENV{'SERVER_NAME'} ]\n";
+print "SERVER_PORT = [ $ENV{'SERVER_PORT'} ]\n";
+print "SERVER_PROTOCOL = [ $ENV{'SERVER_PROTOCOL'} ]\n";
+print "SERVER_SOFTWARE = [ $ENV{'SERVER_SOFTWARE'} ]\n";
+print "\n";
+
+#
+# フォームに指定した値を読み込んで、書き出します。
+#
+print "=================================\n";
+print "フォーム変数\n";
+print "=================================\n";
+if ($ENV{'REQUEST_METHOD'} eq "POST") {
+	# POSTであれば標準入力から読込みます
+	read(STDIN, $query_string, $ENV{'CONTENT_LENGTH'});
+	print "$query_string\n";
+} 
+else {
+	# GETであれば環境変数から読込みます
+	$query_string = $ENV{'QUERY_STRING'};
+#}
+# 「変数名1=値1&変数名2=値2」の形式をアンパサンド( & )で分解します
+@a = split(/&/, $query_string);
+# それぞれの「変数名=値」について
+foreach $a (@a) {
+	# イコール( = )で分解します
+	($name, $value) = split(/=/, $a);
+	# + や %8A などをデコードします
+	$value =~ tr/+/ /;
+	$value =~ s/%([0-9a-fA-F][0-9a-fA-F])/pack("C", hex($1))/eg;
+	# 変数名と値を書き出します
+	print "$name = $value\n";
+	# 後で使用する場合は、$FORM{'変数名'} に代入しておきます
+	$FORM{$name} = $value;
+}
+}
+
+# HTMLの終わりの部分を書き出します。
+#
+print "</XMP>\n";
+print "</BODY>\n";
+print "</HTML>\n";
+print "\n";

--- a/test/unit_test/Session/Makefile
+++ b/test/unit_test/Session/Makefile
@@ -6,7 +6,7 @@
 #    By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2021/03/09 10:22:35 by dnakano           #+#    #+#              #
-#    Updated: 2021/04/24 08:47:48 by dnakano          ###   ########.fr        #
+#    Updated: 2021/04/27 08:16:41 by dnakano          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -43,7 +43,8 @@ TESTSRCNAME	:=	test_main.cc \
 				test_getFileExtension.cc \
 				test_CgiArgvEnvp.cc \
 				test_CgiResponse.cc \
-				test_isCharsetAccepted.cc
+				test_isCharsetAccepted.cc \
+				test_getUriFromLocation.cc
 TESTSRCDIR	:=	.
 
 ### config ###

--- a/test/unit_test/Session/test_getUriFromLocation.cc
+++ b/test/unit_test/Session/test_getUriFromLocation.cc
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   test_getUriFromLocation.cc                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/03/09 10:22:26 by dnakano           #+#    #+#             */
+/*   Updated: 2021/04/27 08:18:48 by dnakano          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#define UNIT_TEST
+
+#include "MainConfig.hpp"
+#include "Session.hpp"
+#include "gtest.h"
+
+class test_getUriFromLocation : public ::testing::Test {
+ protected:
+  MainConfig config;
+  ServerConfig server;
+  LocationConfig location;
+  Session* session;
+  bool flg_thrown;
+
+  virtual void SetUp() {
+    flg_thrown = false;
+    server.addLocation(location);
+    config.addServer(server);
+    session = new Session(0, config);
+    session->server_config_ = &server;
+    session->location_config_ = &location;
+  }
+
+  // 各ケース共通の後処理を書く
+  virtual void TearDown() { delete session; }
+};
+
+TEST_F(test_getUriFromLocation, locationRoot) {
+  std::string res;
+  location.route_ = "/";
+  session->request_.uri_ = "/hoge";
+  res = session->getUriFromLocation();
+
+  EXPECT_EQ(res, "/hoge");
+}
+
+TEST_F(test_getUriFromLocation, locationDirectoryWithSlash) {
+  std::string res;
+  location.route_ = "/directory/";
+  session->request_.uri_ = "/directory/hoge";
+  res = session->getUriFromLocation();
+
+  EXPECT_EQ(res, "/hoge");
+}
+
+TEST_F(test_getUriFromLocation, locationDirectoryWithOutSlash) {
+  std::string res;
+  location.route_ = "/directory";
+  session->request_.uri_ = "/directory/hoge";
+  res = session->getUriFromLocation();
+
+  EXPECT_EQ(res, "/hoge");
+}


### PR DESCRIPTION
locationディレクティブ で指定した際のファイルパスがおかしい問題を修正しました。

### 問題
以下のようなlocationが指定された際に、404が帰る。

```
location /directory/ {
        root ./YoupiBanane;

        limit_except GET;
        index youpi.bad_extension;
}
```

### 原因
locationが指定された際にURIからlocationのroute部分を外さずにfilepathを決定していた。
具体的には、

```
URI: /directory/
root: ./YoupiBanane
```

の場合に、`filepath: ./YoupiBanane/directory/youpi.bad_extension` が指定されていた。（正しくは`./YoupiBanane/youpi.bad_extension`）

### 修正
- locationを除いたuriを得るgetUriFromLocation関数を作成して利用するようにした。
- file read と cgiでそれを使うように変更（他ないはず。多分）

### 反省
早くテスター作って気軽に色んなケース試せるようにします！

### 動作確認
/configfiles/has_location.confを修正して、試せるようにしました。

```
root ./html;

# server
server {
    listen 8888;
    index index.html;
    
    #location
    location /directory/ {
        cgi_extension cgi;
        root ./html/fuga;
        index fuga.html;
    }
}
```

`curl localhost:8888/directory/`、`curl localhost:8888/directory/fuga.html`、`curl localhost:8888/directory/sample.cgi`がそれぞれ動くと思います！