### PR TITLE
fix: bug on PUT to /uploadpass without filename

### DIFF
--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/05/01 00:11:23 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/05/01 15:00:19 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -1581,7 +1581,7 @@ std::string Session::findFileNameFromUri() const {
   std::string res;
   if (*upload_pass.rbegin() == '/') {
     res = uri.substr(upload_pass.length());
-  } else {
+  } else if (uri.length() > upload_pass.length()) {
     res = uri.substr(upload_pass.length() + 1);
   }
   return res;


### PR DESCRIPTION
以下のパターンで例外でてたの直しました。ご確認お願いします。

```
location /upload {
        upload_pass /upload;
        upload_store /uploadstore;
        limit_except GET HEAD PUT;
}
```

の場合に`/upload`にリクエスト投げると例外が出てサーバがクラッシュしてました。
原因はuploadのファイル名を取得する関数内のsubstrで範囲外を参照しているからでした。直しました。