### PR TITLE
check return value of write/send is zero

### DIFF
--- a/Response.cpp
+++ b/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/16 23:50:27 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/05/06 10:39:53 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/05/08 18:10:13 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -149,7 +149,7 @@ ssize_t Response::sendData(int sock_fd, bool header_only, bool is_trace) {
     case 1:  // sending headers
       n = send(sock_fd, status_header_.c_str() + bytes_already_sent_,
                status_header_.length() - bytes_already_sent_, 0);
-      if (n < 0) {
+      if (n == -1 || (n == 0 && status_header_.length() != 0)) {
         return -1;
       }
 
@@ -175,7 +175,7 @@ ssize_t Response::sendData(int sock_fd, bool header_only, bool is_trace) {
       n = send(sock_fd, &body_[bytes_already_sent_],
                body_.size() - bytes_already_sent_, 0);
 
-      if (n < 0) {
+      if (n == -1 || (n == 0 && (body_.size() == bytes_already_sent_))) {
         return -1;
       }
 

--- a/Session.cpp
+++ b/Session.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/06 23:21:37 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/05/07 15:14:59 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/05/08 18:07:46 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -1351,7 +1351,7 @@ int Session::writeToCgi() {
                               request_.getBody().size());
 
   // retry several times even if write failed
-  if (n == -1) {
+  if (n == -1 || (n == 0 && request_.getBody().size() != 0)) {
     std::cout << "Webserv: Session: failed to write to cgi" << std::endl;
     return -1;
   }
@@ -1616,7 +1616,7 @@ int Session::writeToFile() {
   // write to file
   n = write(file_fd_, &(request_.getBody()[0]), request_.getBody().size());
   // retry several times even if write failed
-  if (n == -1) {
+  if (n == -1 || (n == 0 && request_.getBody().size() != 0)) {
     std::cout << "Webserv: Session: failed to write to file" << std::endl;
     return -1;
   }

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/03/10 00:11:38 by dhasegaw          #+#    #+#             */
-/*   Updated: 2021/05/06 11:36:48 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/05/08 18:15:39 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,9 @@ int main(int argc, char** argv) {
   }
 
   // init signal handlers
-  signal(SIGCHLD, SIG_IGN);      // detatch cgi process
+  signal(SIGCHLD, SIG_IGN);  // detatch cgi process
+  signal(SIGPIPE, SIG_IGN);  // server will stop without this when connection
+                             // was closed by the client
   signal(SIGINT, handleSigInt);  // register SIGINT handler
 
   try {


### PR DESCRIPTION
write/send周りで以下修正しました。確認お願いします。

### write/sendの返り値の0チェック
- レビュー項目に合わせました。
- 返り値が0でバッファサイズが0ではない時にエラーを返すよう修正しています。
- 手元で色々確かめた（clientからconnectionを切られた後にsendした場合など）のですがあまり、あまり意味のありそうなものはありませんでした。

### SIGPIPEを無視するように変更
- 上記の調査を進めている上で、clientからconnectionを切られた後にsendした場合、SIGPIPEというSIGNALが発生しプログラムが終了することがわかりました。
- 対策として、mainで一番最初に`signal(SIGPIPE, SIG_IGN)` しています。
- この場合書き込みに失敗するとwrite/sendが-1を返します。
参考： http://doi-t.hatenablog.com/entry/2014/06/10/033309

### テスト
unit/ft/my_tester全てOKです。